### PR TITLE
Allow email/password authentication for every endpoint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,5 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 
   rescue_from ActionController::ParameterMissing, ActionController::UnpermittedParameters do
     head :bad_request

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,15 +7,19 @@ class ApplicationController < ActionController::Base
     head :bad_request
   end
 
-  before_action :authenticate_by_token
+  before_action :authenticate
 
   attr_accessor :current_user
 
   private
 
-  def authenticate_by_token
+  def authenticate
     authenticate_or_request_with_http_basic do |username, password|
-      self.current_user = User.find_by(api_auth_token: username)
+      if user = User.find_by(api_auth_token: username)
+        self.current_user = user
+      elsif user = User.find_by(email: username)
+        self.current_user = user.authenticate(password)
+      end
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,24 +1,9 @@
 class UsersController < ApplicationController
-  skip_before_action :authenticate_by_token, only: [:current]
-  before_action :authenticate_by_token_or_login, only: [:current]
-
   def show
     @user = User.find(params[:id])
   end
 
   def current
     @user = current_user
-  end
-
-  private
-
-  def authenticate_by_token_or_login
-    authenticate_or_request_with_http_basic do |username, password|
-      if user = User.find_by(api_auth_token: username)
-        self.current_user = user
-      elsif user = User.find_by(email: username)
-        self.current_user = user.authenticate(password)
-      end
-    end
   end
 end


### PR DESCRIPTION
…because why not.

This makes it easier to peruse the API via browser, too.
