### PR TITLE
Add the transcripts resource

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,7 +3,7 @@ class MessagesController < ApplicationController
   before_action :load_message, only: [:star, :unstar]
 
   def index
-    @messages = @room.messages.old_to_new
+    @messages = @room.messages.recent
   end
 
   def today

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,7 +3,7 @@ class MessagesController < ApplicationController
   before_action :load_message, only: [:star, :unstar]
 
   def index
-    @messages = @room.messages.recent
+    @messages = @room.messages.recent(params[:limit])
   end
 
   def today

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,9 +1,14 @@
 class MessagesController < ApplicationController
-  before_action :load_room, only: [:index, :create]
+  before_action :load_room, only: [:index, :today, :create]
   before_action :load_message, only: [:star, :unstar]
 
   def index
     @messages = @room.messages.old_to_new
+  end
+
+  def today
+    @messages = @room.messages.today
+    render :index
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,5 @@
 class MessagesController < ApplicationController
-  before_action :load_room, only: [:index, :today, :create]
+  before_action :load_room, only: [:index, :today, :date, :create]
   before_action :load_message, only: [:star, :unstar]
 
   def index
@@ -8,6 +8,11 @@ class MessagesController < ApplicationController
 
   def today
     @messages = @room.messages.today
+    render :index
+  end
+
+  def date
+    @messages = @room.messages.date(params[:year], params[:month], params[:day])
     render :index
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -33,6 +33,12 @@ class Message < ActiveRecord::Base
     old_to_new.where(created_at: today)
   end
 
+  def self.date(year, month, day)
+    date = Date.new(year.to_i, month.to_i, day.to_i)
+    day = date.beginning_of_day..date.end_of_day
+    old_to_new.where(created_at: day)
+  end
+
   def self.post(user, room, attributes)
     attributes.update(user_id: user.id, room_id: room.id, private: room.locked?)
     infer_subclass!(attributes).create(attributes)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -23,10 +23,14 @@ class Message < ActiveRecord::Base
     order(:created_at)
   end
 
+  def self.recent
+    old_to_new.limit(25)
+  end
+
   def self.today
     now = Time.current
     today = now.beginning_of_day..now.end_of_day
-    where(created_at: today).old_to_new
+    old_to_new.where(created_at: today)
   end
 
   def self.post(user, room, attributes)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -23,8 +23,8 @@ class Message < ActiveRecord::Base
     order(:created_at)
   end
 
-  def self.recent
-    old_to_new.limit(25)
+  def self.recent(limit = nil)
+    old_to_new.limit(limit || 25)
   end
 
   def self.today

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -23,6 +23,12 @@ class Message < ActiveRecord::Base
     order(:created_at)
   end
 
+  def self.today
+    now = Time.current
+    today = now.beginning_of_day..now.end_of_day
+    where(created_at: today).old_to_new
+  end
+
   def self.post(user, room, attributes)
     attributes.update(user_id: user.id, room_id: room.id, private: room.locked?)
     infer_subclass!(attributes).create(attributes)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,10 @@ Fireside::Application.routes.draw do
   post "room/:id/lock"   => "rooms#lock"
   post "room/:id/unlock" => "rooms#unlock"
 
-  get "room/:room_id/recent"     => "messages#index"
-  get "room/:room_id/transcript" => "messages#today"
+  get "room/:room_id/recent"                       => "messages#index"
+  get "room/:room_id/transcript"                   => "messages#today"
+  get "room/:room_id/transcript/:year/:month/:day" => "messages#date",
+    constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ }
 
   post "room/:room_id/speak" => "messages#create"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,10 @@ Fireside::Application.routes.draw do
   post "room/:id/lock"   => "rooms#lock"
   post "room/:id/unlock" => "rooms#unlock"
 
-  get  "room/:room_id/recent" => "messages#index"
-  post "room/:room_id/speak"  => "messages#create"
+  get "room/:room_id/recent"     => "messages#index"
+  get "room/:room_id/transcript" => "messages#today"
+
+  post "room/:room_id/speak" => "messages#create"
 
   get "room/:room_id/live" => "live_messages#index"
 

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -215,6 +215,104 @@ describe "Message Requests" do
       end
     end
 
+    describe "GET /room/:room_id/transcript/:year/:month/:day" do
+      let!(:room) { create(:room) }
+
+      context "when authenticated" do
+        let!(:user) { create(:user) }
+
+        before do
+          authenticate(user.api_auth_token)
+        end
+
+        it "lists messages old to new" do
+          create(:text_message, room: room, created_at: Time.new(2014, 2, 9, 12, 0, 0))
+          old_message = create(:text_message, room: room, created_at: Time.new(2014, 2, 10, 12, 0, 0))
+          new_message = create(:text_message, room: room, created_at: Time.new(2014, 2, 10, 12, 0, 1))
+          create(:text_message, room: room, created_at: Time.new(2014, 2, 11, 12, 0, 0))
+
+          get "/room/#{room.id}/transcript/2014/02/10"
+
+          expect(response.status).to eq(200)
+          expect(response.content).to eq(
+            "messages" => [
+              {
+                "body" => old_message.body,
+                "created_at" => old_message.created_at,
+                "id" => old_message.id,
+                "room_id" => old_message.room_id,
+                "starred" => old_message.starred?,
+                "type" => old_message.type,
+                "user_id" => old_message.user_id
+              },
+              {
+                "body" => new_message.body,
+                "created_at" => new_message.created_at,
+                "id" => new_message.id,
+                "room_id" => new_message.room_id,
+                "starred" => new_message.starred?,
+                "type" => new_message.type,
+                "user_id" => new_message.user_id
+              }
+            ]
+          )
+        end
+
+        it "shows expanded sound messages" do
+          message = create(:sound_message, room: room, created_at: Time.new(2014, 2, 10, 12, 0, 0))
+
+          get "/room/#{room.id}/transcript/2014/02/10"
+
+          expect(response.status).to eq(200)
+          expect(response.content).to eq(
+            "messages" => [
+              {
+                "body" => message.body,
+                "created_at" => message.created_at,
+                "description" => message.description,
+                "id" => message.id,
+                "room_id" => message.room_id,
+                "starred" => message.starred?,
+                "type" => message.type,
+                "url" => message.url,
+                "user_id" => message.user_id
+              }
+            ]
+          )
+        end
+
+        it "shows expanded tweet messages" do
+          message = create(:tweet_message, room: room, created_at: Time.new(2014, 2, 10, 12, 0, 0))
+
+          get "/room/#{room.id}/transcript/2014/02/10"
+
+          expect(response.status).to eq(200)
+          expect(response.content).to eq(
+            "messages" => [
+              {
+                "body" => message.body,
+                "created_at" => message.created_at,
+                "id" => message.id,
+                "room_id" => message.room_id,
+                "starred" => message.starred?,
+                "tweet" => message.metadata,
+                "type" => message.type,
+                "user_id" => message.user_id
+              }
+            ]
+          )
+        end
+      end
+
+      context "when unauthenticated" do
+        it "requires authentication" do
+          get "/room/#{room.id}/transcript/2014/02/10"
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+
     describe "POST /room/:room_id/speak" do
       let!(:room) { create(:room) }
 

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -13,7 +13,7 @@ describe "Message Requests" do
         end
 
         it "lists messages old to new" do
-          old_message = create(:text_message, room: room, created_at: 2.minutes.ago)
+          old_message = create(:text_message, room: room, created_at: 1.day.ago)
           new_message = create(:text_message, room: room, created_at: 1.minute.ago)
           create(:text_message)
 
@@ -93,6 +93,104 @@ describe "Message Requests" do
       context "when unauthenticated" do
         it "requires authentication" do
           get "/room/#{room.id}/recent"
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+
+    describe "GET /room/:room_id/transcript" do
+      let!(:room) { create(:room) }
+
+      context "when authenticated" do
+        let!(:user) { create(:user) }
+
+        before do
+          authenticate(user.api_auth_token)
+        end
+
+        it "lists messages old to new" do
+          create(:text_message, room: room, created_at: 1.day.ago)
+          old_message = create(:text_message, room: room, created_at: 2.minutes.ago)
+          new_message = create(:text_message, room: room, created_at: 1.minute.ago)
+          create(:text_message)
+
+          get "/room/#{room.id}/transcript"
+
+          expect(response.status).to eq(200)
+          expect(response.content).to eq(
+            "messages" => [
+              {
+                "body" => old_message.body,
+                "created_at" => old_message.created_at,
+                "id" => old_message.id,
+                "room_id" => old_message.room_id,
+                "starred" => old_message.starred?,
+                "type" => old_message.type,
+                "user_id" => old_message.user_id
+              },
+              {
+                "body" => new_message.body,
+                "created_at" => new_message.created_at,
+                "id" => new_message.id,
+                "room_id" => new_message.room_id,
+                "starred" => new_message.starred?,
+                "type" => new_message.type,
+                "user_id" => new_message.user_id
+              }
+            ]
+          )
+        end
+
+        it "shows expanded sound messages" do
+          message = create(:sound_message, room: room)
+
+          get "/room/#{room.id}/transcript"
+
+          expect(response.status).to eq(200)
+          expect(response.content).to eq(
+            "messages" => [
+              {
+                "body" => message.body,
+                "created_at" => message.created_at,
+                "description" => message.description,
+                "id" => message.id,
+                "room_id" => message.room_id,
+                "starred" => message.starred?,
+                "type" => message.type,
+                "url" => message.url,
+                "user_id" => message.user_id
+              }
+            ]
+          )
+        end
+
+        it "shows expanded tweet messages" do
+          message = create(:tweet_message, room: room)
+
+          get "/room/#{room.id}/transcript"
+
+          expect(response.status).to eq(200)
+          expect(response.content).to eq(
+            "messages" => [
+              {
+                "body" => message.body,
+                "created_at" => message.created_at,
+                "id" => message.id,
+                "room_id" => message.room_id,
+                "starred" => message.starred?,
+                "tweet" => message.metadata,
+                "type" => message.type,
+                "user_id" => message.user_id
+              }
+            ]
+          )
+        end
+      end
+
+      context "when unauthenticated" do
+        it "requires authentication" do
+          get "/room/#{room.id}/transcript"
 
           expect(response.status).to eq(401)
         end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -44,6 +44,15 @@ describe "Message Requests" do
           )
         end
 
+        it "limits to 25 messages by default" do
+          create_list(:text_message, 26, room: room)
+
+          get "/room/#{room.id}/recent"
+
+          expect(response.status).to eq(200)
+          expect(response.content.to_hash["messages"]).to have(25).messages
+        end
+
         it "shows expanded sound messages" do
           message = create(:sound_message, room: room)
 

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -53,6 +53,15 @@ describe "Message Requests" do
           expect(response.content.to_hash["messages"]).to have(25).messages
         end
 
+        it "limits to 25 messages by default" do
+          create_list(:text_message, 11, room: room)
+
+          get "/room/#{room.id}/recent?limit=10"
+
+          expect(response.status).to eq(200)
+          expect(response.content.to_hash["messages"]).to have(10).messages
+        end
+
         it "shows expanded sound messages" do
           message = create(:sound_message, room: room)
 


### PR DESCRIPTION
This exercises the API but the implementation is likely to change in the future. One of the application's goals is the ability to run for free on Heroku and a constraint of that goal is a 10,000 cap for database records. In the end, daily transcripts should be rolled up into one database record in order to avoid that cap.
